### PR TITLE
Exclude ambiguous barcodes etc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CC=g++
 all: flexiplex 
 
 flexiplex: flexiplex.c++ 
-	${CC} $^ -Ofast -pthread -std=c++11 -o $@ edlib-1.2.7/edlib.cpp -I edlib-1.2.7/
+	${CC} $^ -Ofast -pthread -std=c++17 -o $@ edlib-1.2.7/edlib.cpp -I edlib-1.2.7/
 
 clean:
 	rm flexiplex 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CC=g++
 all: flexiplex 
 
 flexiplex: flexiplex.c++ 
-	${CC} $^ -Ofast -pthread -std=c++17 -o $@ edlib-1.2.7/edlib.cpp -I edlib-1.2.7/
+	${CC} $^ -Ofast -pthread -std=c++11 -o $@ edlib-1.2.7/edlib.cpp -I edlib-1.2.7/
 
 clean:
 	rm flexiplex 

--- a/flexiplex.c++
+++ b/flexiplex.c++
@@ -187,7 +187,7 @@ Barcode get_barcode(string & seq,
 
   std::vector<long unsigned int> subpattern_ends;
   subpattern_ends.resize(subpattern_lengths.size());
-  std::inclusive_scan(subpattern_lengths.begin(), subpattern_lengths.end(), subpattern_ends.begin());
+  std::partial_sum(subpattern_lengths.begin(), subpattern_lengths.end(), subpattern_ends.begin());
 
   vector<int> read_to_subpatterns;
   read_to_subpatterns.reserve(subpattern_ends.size());

--- a/flexiplex.c++
+++ b/flexiplex.c++
@@ -299,8 +299,7 @@ void print_stats(string read_id, vector<Barcode> & vec_bc, ostream & out_stream)
 	       << vec_bc.at(b).barcode << "\t"
 	       << vec_bc.at(b).flank_editd << "\t"
 	       << vec_bc.at(b).editd << "\t"
-	       << vec_bc.at(b).umi << "\t"
-	       << endl;
+	       << vec_bc.at(b).umi << endl;
   }
 }
 

--- a/flexiplex.c++
+++ b/flexiplex.c++
@@ -220,12 +220,12 @@ Barcode get_barcode(string & seq,
   
   //if not checking against known list of barcodes, return sequence after the primer
   //also check for a perfect match straight up as this will save computer later.
-  string exact_bc=seq.substr(read_to_subpatterns[0], read_to_subpatterns[1]);
+  string exact_bc=seq.substr(read_to_subpatterns[0], read_to_subpatterns[1] - read_to_subpatterns[0]);
   if(known_barcodes->size()==0 || (known_barcodes->find(exact_bc) != known_barcodes->end())){ 
     barcode.barcode=exact_bc;
     barcode.editd=0;
     barcode.unambiguous=true;
-    barcode.umi=seq.substr(read_to_subpatterns[1], read_to_subpatterns[2]);//resul
+    barcode.umi=seq.substr(read_to_subpatterns[1], search_pattern.umi_seq.length());
     return(barcode);
   }
   


### PR DESCRIPTION
Previous PR had a bug, fixed in [commit 17393df606269432c5146458e0d4e922bd6b3f49](https://github.com/ChangqingW/flexiplex/commit/17393df606269432c5146458e0d4e922bd6b3f49)
Exclude ambiguous barcodes [0c565c67137ede87d2700936aa05e90548249e5f](https://github.com/ChangqingW/flexiplex/commit/0c565c67137ede87d2700936aa05e90548249e5f)
use aligment for locating barcode instead of searching for primer again
remove extra `\t` in `flexiplex_reads_barcodes.txt` [43a10f7e688161a2d6dd36364733d520345fc423](https://github.com/ChangqingW/flexiplex/commit/43a10f7e688161a2d6dd36364733d520345fc423)