### PR TITLE
Add a flag to report chimeric reads

### DIFF
--- a/flexiplex.c++
+++ b/flexiplex.c++
@@ -564,9 +564,9 @@ void search_read(vector<SearchResult> & reads, unordered_set<string> & known_bar
 
     reads[r].count = forward_reads.size() + reverse_reads.size();
 
-    // a chimeric read occurs when there are more than 1 detected barcodes in
-    // a single read
-    reads[r].chimeric = reads[r].count > 1;
+    // a chimeric read occurs when there are barcodes detected in both the forward
+    // and reverse strands.
+    reads[r].chimeric = forward_reads.size() && reverse_reads.size();
   }
 }
 


### PR DESCRIPTION
This PR adds a new flag, `-c true/false`, which controls whether Flexiplex should report chimeric reads. With it enabled, any chimeric reads will be labelled with a `_C` suffix in the read identifier. By default, this is **false** so despite the change in identifier, by default, all pipelines should still work with no change in functionality.

For instance, when this option is enabled, if the read with identifier `@BC_UMI#READID_+1of2` is chimeric, it will become `@BC_UMI#READID_+1of2_C`.