### PR TITLE
add CB UB tag to fastq id field

### DIFF
--- a/flexiplex.c++
+++ b/flexiplex.c++
@@ -515,8 +515,9 @@ void print_read(string read_id, string read, string qual,
       }
 
       string barcode = vec_bc.at(b).barcode;
+      // also add the proper FASTQ way: \tCB:Z:barcode\tUB:Z:umi
       string new_read_id =
-          barcode + "_" + vec_bc.at(b).umi + "#" + read_id + ss.str();
+          barcode + "_" + vec_bc.at(b).umi + "#" + read_id + ss.str() + "\tCB:Z:" + barcode + "\tUB:Z:" + vec_bc[b].umi;
 
       // work out the start and end base in case multiple barcodes
       int read_start = vec_bc.at(b).flank_end;


### PR DESCRIPTION
Minimap2 support including cell barcode and UMI tag from FASTQ id field to the SAM output. They need to be included as `\tCB:Z:barcode\tUB:Z:umi`.
```bash
> man minimap2
...
-y        Copy input FASTA/Q comments to output.
```
oarfish has a single-cell mode that requires the `CB` tag, see:
https://github.com/COMBINE-lab/oarfish/releases/tag/v0.6.1
https://github.com/COMBINE-lab/oarfish/issues/31